### PR TITLE
feat: implementacao de dynamic query filtering com specification + testes service e repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.0</version>
+		<version>3.5.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.study</groupId>
@@ -58,6 +58,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/study/taskAPI/controller/TaskController.java
+++ b/src/main/java/com/study/taskAPI/controller/TaskController.java
@@ -2,7 +2,10 @@ package com.study.taskAPI.controller;
 
 import com.study.taskAPI.dto.TaskCreateRequest;
 import com.study.taskAPI.dto.TaskResponse;
+import com.study.taskAPI.dto.TaskSummaryResponse;
 import com.study.taskAPI.dto.TaskUpdateRequest;
+import com.study.taskAPI.enums.Priority;
+import com.study.taskAPI.enums.Status;
 import com.study.taskAPI.service.TaskService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -26,6 +30,16 @@ public class TaskController {
     @GetMapping("/{id}")
     public ResponseEntity<TaskResponse> getTaskById(@PathVariable Integer id) {
         return ResponseEntity.status(HttpStatus.OK).body(service.getTaskById(id));
+    }
+
+    @GetMapping("/filter")
+    public ResponseEntity<List<TaskSummaryResponse>> getFilteredTaskSummaries(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) Priority priority,
+            @RequestParam(required = false) Status status,
+            @RequestParam(required = false) LocalDate dueDateBefore,
+            @RequestParam(required = false) LocalDate dueDateAfter) {
+        return ResponseEntity.status(HttpStatus.OK).body(service.getFilteredTaskSummaries(title, priority, status, dueDateBefore, dueDateAfter));
     }
 
     @PostMapping("/")

--- a/src/main/java/com/study/taskAPI/dto/TaskFilterRequest.java
+++ b/src/main/java/com/study/taskAPI/dto/TaskFilterRequest.java
@@ -1,0 +1,23 @@
+package com.study.taskAPI.dto;
+
+import com.study.taskAPI.enums.Priority;
+import com.study.taskAPI.enums.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TaskFilterRequest {
+    private String title;
+    private String description;
+    private LocalDate dueDate;
+    private Status status;
+    private Priority priority;
+
+}

--- a/src/main/java/com/study/taskAPI/repository/TaskRepository.java
+++ b/src/main/java/com/study/taskAPI/repository/TaskRepository.java
@@ -3,11 +3,12 @@ package com.study.taskAPI.repository;
 import com.study.taskAPI.enums.Status;
 import com.study.taskAPI.model.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface TaskRepository extends JpaRepository<Task, Integer> {
+public interface TaskRepository extends JpaRepository<Task, Integer>, JpaSpecificationExecutor<Task> {
     List<Task> findByStatus(Status status);
 }

--- a/src/main/java/com/study/taskAPI/service/TaskService.java
+++ b/src/main/java/com/study/taskAPI/service/TaskService.java
@@ -1,23 +1,25 @@
 package com.study.taskAPI.service;
 
-import com.study.taskAPI.dto.TaskCreateRequest;
-import com.study.taskAPI.dto.TaskResponse;
-import com.study.taskAPI.dto.TaskSummaryResponse;
-import com.study.taskAPI.dto.TaskUpdateRequest;
+import com.study.taskAPI.dto.*;
 import com.study.taskAPI.dto.mapper.TaskCreateRequestMapper;
 import com.study.taskAPI.dto.mapper.TaskResponseMapper;
 import com.study.taskAPI.dto.mapper.TaskSummaryResponseMapper;
 import com.study.taskAPI.dto.mapper.TaskUpdateRequestMapper;
+import com.study.taskAPI.enums.Priority;
 import com.study.taskAPI.enums.Status;
 import com.study.taskAPI.model.Task;
 import com.study.taskAPI.repository.TaskRepository;
+import com.study.taskAPI.utils.TaskSpecification;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
+
+import static com.study.taskAPI.utils.TaskSpecification.*;
 
 @Service
 public class TaskService {
@@ -59,5 +61,14 @@ public class TaskService {
     public TaskResponse getTaskById(int id) {
         Task task = repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tarefa de id %d não encontrada".formatted(id)));
         return taskResponseMapper.toDTO(task);
+    }
+
+    public List<TaskSummaryResponse> getFilteredTaskSummaries(String title, Priority priority, Status status, LocalDate dueDateBefore, LocalDate dueDateAfter) {
+        Specification<Task> spec = Specification.where(withTitleLike(title))
+                                                .and(withPriority(priority))
+                                                .and(withStatus(status))
+                                                .and(withDueDateBefore(dueDateBefore))
+                                                .and(withDueDateAfter(dueDateAfter));
+        return taskSummaryResponseMapper.toDTOList(repository.findAll(spec));
     }
 }

--- a/src/main/java/com/study/taskAPI/utils/TaskSpecification.java
+++ b/src/main/java/com/study/taskAPI/utils/TaskSpecification.java
@@ -1,0 +1,44 @@
+    package com.study.taskAPI.utils;
+
+    import com.study.taskAPI.enums.Priority;
+    import com.study.taskAPI.enums.Status;
+    import com.study.taskAPI.model.Task;
+    import org.springframework.data.jpa.domain.Specification;
+
+    import java.time.LocalDate;
+
+    public class TaskSpecification {
+        public static Specification<Task> withTitleLike(String title) {
+            return (root, query, builder) ->
+                    (title == null || title.isBlank() ?
+                    builder.conjunction() :
+                    builder.like(builder.lower(root.get("title")), "%" + title.toLowerCase() + "%"));
+        }
+        public static Specification<Task> withStatus(Status status) {
+            return (root, query, builder) ->
+                    (status == null ?
+                    builder.conjunction() :
+                    builder.equal(root.get("status"), status));
+        }
+
+        public static Specification<Task> withPriority(Priority priority) {
+            return (root, query, builder) ->
+                    (priority == null ?
+                    builder.conjunction() :
+                    builder.equal(root.get("priority"), priority));
+        }
+
+        public static Specification<Task> withDueDateBefore(LocalDate dueDateBefore) {
+            return (root, query, builder) ->
+                    (dueDateBefore == null ?
+                    builder.conjunction() :
+                    builder.lessThan(root.get("dueDate"), dueDateBefore));
+        }
+
+        public static Specification<Task> withDueDateAfter(LocalDate dueDateAfter) {
+            return (root, query, builder) ->
+                    (dueDateAfter == null ?
+                    builder.conjunction() :
+                    builder.greaterThan(root.get("dueDate"), dueDateAfter));
+        }
+    }

--- a/src/test/java/com/study/taskAPI/repository/TaskRepositoryTest.java
+++ b/src/test/java/com/study/taskAPI/repository/TaskRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.study.taskAPI.repository;
+
+import com.study.taskAPI.enums.Priority;
+import com.study.taskAPI.enums.Status;
+import com.study.taskAPI.model.Task;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.study.taskAPI.utils.TaskSpecification.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@DataJpaTest
+public class TaskRepositoryTest {
+    @Autowired
+    private TaskRepository repository;
+
+    @Test
+    public void shouldReturnTasks_whenTitlePriorityAndStatusAreFiltered() {
+        Task task1 = new Task(null, "Título teste 1", "Descrição teste 1", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+        Task task2 = new Task(null, "Título teste 2", "Descrição teste 2", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+        Task task3 = new Task(null, "Título teste 3", "Descrição teste 3", LocalDate.of(2025,7,6), Priority.LOW, Status.TO_DO);
+
+        repository.save(task1);
+        repository.save(task2);
+        repository.save(task3);
+
+        Specification<Task> spec = Specification.where(withTitleLike("Título")
+                                                .and(withPriority(Priority.LOW))
+                                                .and(withStatus(Status.DONE)));
+
+        List<Task> results = repository.findAll(spec);
+
+        assertThat(results).hasSize(2);
+
+        assertThat(results)
+                .extracting("title", "priority", "status")
+                .containsExactlyInAnyOrder(
+                        tuple("Título teste 1", Priority.LOW, Status.DONE),
+                        tuple("Título teste 2", Priority.LOW, Status.DONE)
+                );
+    }
+
+    @Test
+    void shouldReturnEmptyList_whenTitlePriorityAndStatusDoNotMatchAnyTask() {
+        Task task1 = new Task(null, "Título teste 1", "Descrição teste 1", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+        Task task2 = new Task(null, "Título teste 2", "Descrição teste 2", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+
+        repository.save(task1);
+        repository.save(task2);
+
+        Specification<Task> spec = Specification.where(withTitleLike("task"))
+                                                .and(withPriority(Priority.LOW))
+                                                .and(withStatus(Status.DONE));
+
+        List<Task> results = repository.findAll(spec);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAllTasks_whenFilterIsNotPresent() {
+        Task task1 = new Task(null, "Título teste 1", "Descrição teste 1", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+        Task task2 = new Task(null, "Título teste 2", "Descrição teste 2", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+
+        repository.save(task1);
+        repository.save(task2);
+
+        Specification<Task> spec = Specification.where(withTitleLike(null))
+                                                .and(withPriority(null))
+                                                .and(withStatus(null))
+                                                .and(withDueDateBefore(null))
+                                                .and(withDueDateAfter(null));
+
+        List<Task> results = repository.findAll(spec);
+
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void shouldReturnTasks_whenNotAllFiltersArePresent() {
+        Task task1 = new Task(null, "Título teste 1", "Descrição teste 1", LocalDate.of(2025,7,6), Priority.LOW, Status.DONE);
+        Task task2 = new Task(null, "Título teste 2", "Descrição teste 2", LocalDate.of(2025,7,9), Priority.LOW, Status.DONE);
+        Task task3 = new Task(null, "Título teste 3", "Descrição teste 3", LocalDate.of(2025,7,6), Priority.LOW, Status.TO_DO);
+
+        repository.save(task1);
+        repository.save(task2);
+        repository.save(task3);
+
+        Specification<Task> spec = Specification.where(withTitleLike("Título"))
+                                                .and(withPriority(Priority.LOW))
+                                                .and(withStatus(null))
+                                                .and(withDueDateBefore(LocalDate.of(2025,7,8)))
+                                                .and(withDueDateAfter(null));
+
+        List<Task> results = repository.findAll(spec);
+
+        assertThat(results).hasSize(2);
+        assertThat(results)
+                .extracting("title", "priority", "dueDate")
+                .containsExactlyInAnyOrder(
+                        tuple("Título teste 1", Priority.LOW, LocalDate.of(2025, 7, 6)),
+                        tuple("Título teste 3", Priority.LOW, LocalDate.of(2025, 7, 6))
+                );
+    }
+}


### PR DESCRIPTION
endpoint com @RequestParam required = false para receber os filtros da requisição;
service com Specification de filtros existentes, busca no repository os registros que atendem aos filtros e retorna uma lista de DTOs de TaskSummaryResponse com apenas os atributos necessários;
classe de specification para Task com os filtros de 'withTitleLike', 'withStatus', 'withPriority', 'withDueDateBefore', 'withDueDateAfter';
teste unitário da camada service que testa se é retornado as Tasks quando apenas os atributos title, priority e status existem para filtragem;
testes unitários na camada repository para testar se os filtros utilizando Specification estão funcionando corretamente, com testes utilizando apenas alguns filtros, sem nenhum filtro e quando os filtros passados não encontram resultados.